### PR TITLE
Generalize usage of ConfigureAwait(false) to avoid deadlocks if calling service has synchronization context

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ var tree = await commit.GetTreeAsync();
 
 | Method                         | Mean    | Error   | StdDev   |
 |------------------------------- |--------:|--------:|---------:|
-| GitDotNet                      | 5.459 s | 2.093 s | 0.1147 s |
+| GitDotNet                      | 5.404 s | 1.141 s | 0.0626 s |
 | git archive -o result.zip HEAD | 7.357 s | 6.893 s | 0.3778 s |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ var tree = await commit.GetTreeAsync();
 
 | Method                         | Mean    | Error   | StdDev   |
 |------------------------------- |--------:|--------:|---------:|
-| GitDotNet                      | 6.200 s | 2.676 s | 0.1467 s |
+| GitDotNet                      | 5.459 s | 2.093 s | 0.1147 s |
 | git archive -o result.zip HEAD | 7.357 s | 6.893 s | 0.3778 s |
 
 ## Contributing

--- a/src/GitDotNet.Console/DumpIndexContent.cs
+++ b/src/GitDotNet.Console/DumpIndexContent.cs
@@ -10,9 +10,9 @@ public class DumpIndexContent(GitConnectionProvider factory) : BackgroundService
     {
         var path = InputData(RepositoryPathInput, Directory.Exists);
         using var connection = factory.Invoke(path);
-        var entries = await connection.Index.GetEntriesAsync();
+        var entries = await connection.Index.GetEntriesAsync().ConfigureAwait(false);
         Print(entries);
-        await StopAsync(stoppingToken);
+        await StopAsync(stoppingToken).ConfigureAwait(false);
     }
 
     private static void Print(IEnumerable<IndexEntry> entries)

--- a/src/GitDotNet/Data/Branch.cs
+++ b/src/GitDotNet/Data/Branch.cs
@@ -55,7 +55,7 @@ public class Branch : IAsyncEnumerable<LogEntry>, IComparable<Branch>, IEquatabl
     }
 
     /// <summary>Gets the tip commit of the branch.</summary>
-    public async Task<CommitEntry> GetTipAsync() => await Connection.Objects.GetAsync<CommitEntry>(_tipProvider());
+    public async Task<CommitEntry> GetTipAsync() => await Connection.Objects.GetAsync<CommitEntry>(_tipProvider()).ConfigureAwait(false);
 
     /// <summary>
     /// Updates a reference in the Git repository to point to a new commit. This operation modifies the reference to the
@@ -179,7 +179,7 @@ public class Branch : IAsyncEnumerable<LogEntry>, IComparable<Branch>, IEquatabl
         }
 
         /// <summary>
-        /// Removes a specified branch from the repository. The removal can be forced or done safely depending on the
+        /// Removes a specified branch from the repository. The removal can be force or done safely depending on the
         /// provided option.
         /// </summary>
         /// <param name="name">Specifies the branch to be removed from the repository.</param>

--- a/src/GitDotNet/Data/CommitEntry.cs
+++ b/src/GitDotNet/Data/CommitEntry.cs
@@ -55,14 +55,14 @@ public class CommitEntry : Entry
     [ExcludeFromCodeCoverage]
     public async Task<TreeEntry> GetRootTreeAsync() => _tree ??=
         _treeId != null || !string.IsNullOrEmpty(_content.Value.Tree) ?
-        await _objectResolver.GetAsync<TreeEntry>(_treeId ?? _content.Value.Tree.HexToByteArray()) :
+        await _objectResolver.GetAsync<TreeEntry>(_treeId ?? _content.Value.Tree.HexToByteArray()).ConfigureAwait(false) :
         throw new InvalidOperationException("Cannot get tree from a new empty commit.");
 
     /// <summary>Asynchronously gets the parent commits of the current commit.</summary>
     /// <returns>A list of parent commits.</returns>
     public async Task<IList<CommitEntry>> GetParentsAsync()
     {
-        return _parents ??= await LookupParents();
+        return _parents ??= await LookupParents().ConfigureAwait(false);
 
         async Task<IList<CommitEntry>> LookupParents()
         {
@@ -70,7 +70,7 @@ public class CommitEntry : Entry
             var parents = ImmutableList.CreateBuilder<CommitEntry>();
             foreach (var parent in _parentIds)
             {
-                var commit = await _objectResolver.GetAsync<CommitEntry>(parent);
+                var commit = await _objectResolver.GetAsync<CommitEntry>(parent).ConfigureAwait(false);
                 parents.Add(commit);
             }
             return parents.ToImmutable();

--- a/src/GitDotNet/Data/IndexEntry.cs
+++ b/src/GitDotNet/Data/IndexEntry.cs
@@ -46,7 +46,8 @@ public record IndexEntry
     /// <summary>Retrieves an entry asynchronously./// </summary>
     /// <typeparam name="TEntry">Represents the type of entry being retrieved.</typeparam>
     /// <returns>Returns the entry of the specified type.</returns>
-    public async Task<TEntry> GetEntryAsync<TEntry>() where TEntry : Entry => (TEntry)(_entry ??= await _objectResolver.GetAsync<TEntry>(Id));
+    public async Task<TEntry> GetEntryAsync<TEntry>() where TEntry : Entry =>
+        (TEntry)(_entry ??= await _objectResolver.GetAsync<TEntry>(Id).ConfigureAwait(false));
 
     /// <summary>Prints the members of the <see cref="IndexEntry"/> to the provided <see cref="StringBuilder"/>.</summary>
     /// <param name="builder">The <see cref="StringBuilder"/> to append the member information to.</param>

--- a/src/GitDotNet/Data/LogEntry.cs
+++ b/src/GitDotNet/Data/LogEntry.cs
@@ -33,12 +33,14 @@ public class LogEntry(HashId commitId, HashId treeId, IList<HashId> parentIds, D
 
     /// <summary>Asynchronously retrieves the <see cref="CommitEntry"/> associated with this log entry.</summary>
     /// <returns>The task result contains the <see cref="CommitEntry"/> associated with this log entry.</returns>
-    public async Task<CommitEntry> GetCommitAsync() => _commit ??= await _objectResolver.GetAsync<CommitEntry>(CommitId);
+    public async Task<CommitEntry> GetCommitAsync() =>
+        _commit ??= await _objectResolver.GetAsync<CommitEntry>(CommitId).ConfigureAwait(false);
 
     /// <summary>Asynchronously retrieves the <see cref="TreeEntry"/> associated with this log entry.</summary>
     /// <returns>The task result contains the <see cref="TreeEntry"/> associated with this log entry.</returns>
     [ExcludeFromCodeCoverage]
-    public async Task<TreeEntry> GetRootTreeAsync() => _tree ??= await _objectResolver.GetAsync<TreeEntry>(TreeId);
+    public async Task<TreeEntry> GetRootTreeAsync() =>
+        _tree ??= await _objectResolver.GetAsync<TreeEntry>(TreeId).ConfigureAwait(false);
 
     /// <summary>Asynchronously retrieves the parent commits of this log entry.</summary>
     /// <returns>The task result contains the parent commits associated with this log entry.</returns>
@@ -47,7 +49,7 @@ public class LogEntry(HashId commitId, HashId treeId, IList<HashId> parentIds, D
         if (_parents is null)
         {
             var tasks = ParentIds.Select(_objectResolver.GetAsync<LogEntry>);
-            _parents = ImmutableList.Create(await Task.WhenAll(tasks));
+            _parents = ImmutableList.Create(await Task.WhenAll(tasks).ConfigureAwait(false));
         }
         return _parents;
     }

--- a/src/GitDotNet/Data/TagEntry.cs
+++ b/src/GitDotNet/Data/TagEntry.cs
@@ -32,7 +32,7 @@ public sealed class TagEntry : Entry
     /// <summary>Asynchronously gets the target object associated with the tag.</summary>
     /// <returns>The target object associated with the tag.</returns>
     public async Task<Entry> GetTargetAsync() =>
-        _target ??= await _objectResolver.GetAsync<Entry>(_content.Value.Object.HexToByteArray());
+        _target ??= await _objectResolver.GetAsync<Entry>(_content.Value.Object.HexToByteArray()).ConfigureAwait(false);
 
     private Content Parse()
     {

--- a/src/GitDotNet/Data/TreeEntry.cs
+++ b/src/GitDotNet/Data/TreeEntry.cs
@@ -26,7 +26,7 @@ public class TreeEntry : Entry
         var child = Children.FirstOrDefault(x => x.Name.Equals(path.Root, StringComparison.Ordinal));
         if (child is not null && path.Length > 1)
         {
-            return await child.GetRelativePathAsync(path.ChildPath);
+            return await child.GetRelativePathAsync(path.ChildPath).ConfigureAwait(false);
         }
         return child;
     }
@@ -38,7 +38,7 @@ public class TreeEntry : Entry
     {
         foreach (var child in Children)
         {
-            var path = await child.TryGetRelativePathToAsync(entry);
+            var path = await child.TryGetRelativePathToAsync(entry).ConfigureAwait(false);
             if (path is not null)
                 return path;
         }
@@ -52,8 +52,8 @@ public class TreeEntry : Entry
     public async IAsyncEnumerable<(GitPath Path, TreeEntryItem BlobEntry)> GetAllBlobEntriesAsync(GitPath? basePath = null, CancellationToken cancellationToken = default)
     {
         var channel = Channel.CreateUnbounded<(GitPath Path, TreeEntryItem Stream)>();
-        var task = GetAllBlobEntriesAsync(channel, x => x, basePath, cancellationToken);
-        await foreach (var result in channel.Reader.ReadAllAsync())
+        var task = GetAllBlobEntriesAsync(channel, x => x, basePath, cancellationToken).ConfigureAwait(false);
+        await foreach (var result in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return result;
         }
@@ -73,7 +73,7 @@ public class TreeEntry : Entry
         foreach (var child in Children)
         {
             path.Add(child.Name);
-            await child.GetAllBlobEntriesAsync(channel, func, path, cancellationToken);
+            await child.GetAllBlobEntriesAsync(channel, func, path, cancellationToken).ConfigureAwait(false);
             path.RemoveAt(path.Count - 1);
         }
         channel.Writer.Complete();

--- a/src/GitDotNet/GitConnection.Write.cs
+++ b/src/GitDotNet/GitConnection.Write.cs
@@ -30,7 +30,7 @@ public partial class GitConnection
         GitCliCommand.Execute(Info.RootFilePath, command, updateEnvironmentVariables: AddCommitter);
         (Objects as IObjectResolverInternal)?.PackManager.UpdatePacks(force: true);
 
-        return await Head.GetTipAsync();
+        return await Head.GetTipAsync().ConfigureAwait(false);
 
         void AddCommitter(StringDictionary env)
         {
@@ -55,7 +55,7 @@ public partial class GitConnection
         {
             transformations(c);
             return Task.FromResult(c);
-        }, commit, options);
+        }, commit, options).ConfigureAwait(false);
 
     /// <summary>
     /// Commits the changes in the transformation composer to the repository.
@@ -72,12 +72,12 @@ public partial class GitConnection
         var canonicalName = Reference.LooksLikeLocalBranch(branchName) ? branchName : $"{Reference.LocalBranchPrefix}{branchName}";
 
         var composer = _transformationComposerFactory(Info.Path);
-        await transformations(composer);
+        await transformations(composer).ConfigureAwait(false);
 
-        var result = await composer.CommitAsync(canonicalName, commit, options);
+        var result = await composer.CommitAsync(canonicalName, commit, options).ConfigureAwait(false);
         (Objects as IObjectResolverInternal)?.PackManager.UpdatePacks(force: true);
 
-        return await Objects.GetAsync<CommitEntry>(result!);
+        return await Objects.GetAsync<CommitEntry>(result!).ConfigureAwait(false);
     }
 
     /// <summary>Creates a new in-memory commit entry before it gets committed to repository.</summary>

--- a/src/GitDotNet/GitConnection.cs
+++ b/src/GitDotNet/GitConnection.cs
@@ -87,7 +87,7 @@ public partial class GitConnection : IDisposable
     /// <param name="committish">The committish reference.</param>
     /// <returns>The commit hash as a byte array.</returns>
     public async Task<CommitEntry> GetCommittishAsync(string committish) =>
-        await GetCommittishAsync<CommitEntry>(committish, c => c.ParentIds);
+        await GetCommittishAsync<CommitEntry>(committish, c => c.ParentIds).ConfigureAwait(false);
 
     internal async Task<T> GetCommittishAsync<T>(string committish, Func<T, IList<HashId>> parentProvider)
         where T : Entry
@@ -98,7 +98,7 @@ public partial class GitConnection : IDisposable
         {
             reference = matches[0].Groups["ref"].Value;
             var commitId = GetReferenceTip(reference);
-            var commit = await Objects.GetAsync<T>(commitId);
+            var commit = await Objects.GetAsync<T>(commitId).ConfigureAwait(false);
 
             foreach (Match match in matches)
             {
@@ -108,7 +108,7 @@ public partial class GitConnection : IDisposable
                 var traversed = TraverseCommit(commitId, parentProvider(commit) , op, num);
                 if (traversed != commitId)
                 {
-                    commit = await Objects.GetAsync<T>(traversed);
+                    commit = await Objects.GetAsync<T>(traversed).ConfigureAwait(false);
                 }
             }
             return commit;
@@ -116,7 +116,7 @@ public partial class GitConnection : IDisposable
         else
         {
             var commitId = GetReferenceTip(reference);
-            return await Objects.GetAsync<T>(commitId);
+            return await Objects.GetAsync<T>(commitId).ConfigureAwait(false);
         }
 
         HashId GetReferenceTip(string reference) => reference switch
@@ -150,16 +150,16 @@ public partial class GitConnection : IDisposable
     /// <param name="new">The new <see cref="TreeEntry"/> instance.</param>
     /// <returns>A list of changes between the two <see cref="TreeEntry"/> instances.</returns>
     public virtual async Task<IList<Change>> CompareAsync(TreeEntry? old, TreeEntry @new) =>
-        await _comparer.CompareAsync(old, @new);
+        await _comparer.CompareAsync(old, @new).ConfigureAwait(false);
 
     /// <summary>Compares two <see cref="CommitEntry"/> instances by comparing their associated tree entries.</summary>
     /// <param name="old">The old <see cref="CommitEntry"/> instance.</param>
     /// <param name="new">The new <see cref="CommitEntry"/> instance.</param>
     public virtual async Task<IList<Change>> CompareAsync(CommitEntry? old, CommitEntry @new)
     {
-        var oldTree = old != null ? await old.GetRootTreeAsync() : null;
-        var newTree = await @new.GetRootTreeAsync();
-        return await CompareAsync(oldTree, newTree);
+        var oldTree = old != null ? await old.GetRootTreeAsync().ConfigureAwait(false) : null;
+        var newTree = await @new.GetRootTreeAsync().ConfigureAwait(false);
+        return await CompareAsync(oldTree, newTree).ConfigureAwait(false);
     }
 
     /// <summary>Compares two commit references by comparing their associated commit entries.</summary>
@@ -167,9 +167,9 @@ public partial class GitConnection : IDisposable
     /// <param name="new">The new reference.</param>
     public virtual async Task<IList<Change>> CompareAsync(string? old, string @new)
     {
-        var oldCommit = old != null ? await GetCommittishAsync(old) : null;
-        var newCommit = await GetCommittishAsync(@new);
-        return await CompareAsync(oldCommit, newCommit);
+        var oldCommit = old != null ? await GetCommittishAsync(old).ConfigureAwait(false) : null;
+        var newCommit = await GetCommittishAsync(@new).ConfigureAwait(false);
+        return await CompareAsync(oldCommit, newCommit).ConfigureAwait(false);
     }
 
     /// <summary>Determines whether the specified path is a valid Git repository.</summary>

--- a/src/GitDotNet/Index.cs
+++ b/src/GitDotNet/Index.cs
@@ -26,7 +26,8 @@ public class Index
 
     /// <summary>Gets the entries from the index file asynchronously.</summary>
     /// <returns>A task that represents the asynchronous operation. The task result contains a list of <see cref="IndexEntry"/> instances.</returns>
-    public async Task<IImmutableList<IndexEntry>> GetEntriesAsync() => await _indexReader.GetEntriesAsync();
+    public async Task<IImmutableList<IndexEntry>> GetEntriesAsync() =>
+        await _indexReader.GetEntriesAsync().ConfigureAwait(false);
 
     /// <summary>Adds a new entry to the Git index using a byte array as content.</summary>
     /// <param name="data">The byte array containing the data to be added to the Git index.</param>

--- a/src/GitDotNet/ObjectResolver.cs
+++ b/src/GitDotNet/ObjectResolver.cs
@@ -64,7 +64,7 @@ internal partial class ObjectResolver : IObjectResolver, IObjectResolverInternal
         var result = default(UnlinkedEntry?);
         for (int i = 0; i < attempts; i++)
         {
-            result = await TryReadUnlinkedEntryAsync(id, throwIfNotFound && i == attempts - 1);
+            result = await ReadUnlinkedEntryAsync(id, throwIfNotFound && i == attempts - 1);
             if (result is null && i < attempts - 1)
             {
                 // Protect against filesystem changes not being immediately visible
@@ -80,7 +80,7 @@ internal partial class ObjectResolver : IObjectResolver, IObjectResolverInternal
         return result is null || result.Id.Hash.Count > 0 ? result : result with { Id = id };
     }
 
-    private async Task<UnlinkedEntry?> TryReadUnlinkedEntryAsync(HashId id, bool throwIfNotFound)
+    private async Task<UnlinkedEntry?> ReadUnlinkedEntryAsync(HashId id, bool throwIfNotFound)
     {
         ObjectDisposedException.ThrowIf(_disposedValue, this);
 

--- a/src/GitDotNet/PackManager.cs
+++ b/src/GitDotNet/PackManager.cs
@@ -36,21 +36,16 @@ internal class PackManager(string path, IFileSystem fileSystem, PackReaderFactor
     /// <summary>Updates pack readers based on the current state of pack files.</summary>
     public void UpdatePacks(bool force)
     {
-        var packDir = fileSystem.Path.Combine(path, "pack");
-        DateTime? currentTimestamp = fileSystem.Directory.Exists(packDir) ?
-            fileSystem.Directory.GetFiles(packDir, "*.pack")
-                .Select(file => fileSystem.File.GetLastWriteTimeUtc(file))
-                .DefaultIfEmpty(DateTime.MinValue)
-                .Max() is var maxTime && maxTime != DateTime.MinValue ? maxTime : null :
-            null;
-        
-        if (!force && _lastInfoPacksTimestamp != null && _lastInfoPacksTimestamp == currentTimestamp) 
+        if (_lastInfoPacksTimestamp != null && !force)
+        {
+            // If the last timestamp is not null and force is false, we can skip the update.
             return;
-
+        }
+        var packDir = fileSystem.Path.Combine(path, "pack");
         var validPackNames = AddFromPackDir(packDir);
 
         MarkPacksAsObsolete(validPackNames);
-        _lastInfoPacksTimestamp = currentTimestamp;
+        _lastInfoPacksTimestamp = DateTime.Now;
     }
 
     private HashSet<string> AddFromPackDir(string packDir)

--- a/src/GitDotNet/Readers/IndexReader.cs
+++ b/src/GitDotNet/Readers/IndexReader.cs
@@ -24,13 +24,13 @@ internal class IndexReader(string path, IObjectResolver objectResolver, IFileSys
             var version = ReadVersion(stream, fourByteBuffer);
 
             stream.Seek(8L, SeekOrigin.Begin);
-            await stream.ReadExactlyAsync(fourByteBuffer.AsMemory(0, 4));
+            await stream.ReadExactlyAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             var entryCount = BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
             var result = ImmutableList.CreateBuilder<IndexEntry>();
             for (int i = 0; i < entryCount; i++)
             {
-                var entry = await ReadEntryAsync(stream, objectResolver, version);
+                var entry = await ReadEntryAsync(stream, objectResolver, version).ConfigureAwait(false);
                 result.Add(entry);
             }
             return result.ToImmutable();
@@ -52,40 +52,40 @@ internal class IndexReader(string path, IObjectResolver objectResolver, IFileSys
         var fourByteBuffer = ArrayPool<byte>.Shared.Rent(4);
         try
         {
-            var read = await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            var read = await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             var cTime = BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             var cTimeNano = BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             var mTime = BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             var mTimeNano = BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             var mode = BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 4)).ConfigureAwait(false);
             var fileSize = BinaryPrimitives.ReadInt32BigEndian(fourByteBuffer.AsSpan(0, 4));
 
             var hash = new byte[20];
-            read += await stream.ReadAsync(hash.AsMemory(0, 20));
+            read += await stream.ReadAsync(hash.AsMemory(0, 20)).ConfigureAwait(false);
 
-            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 2));
+            read += await stream.ReadAsync(fourByteBuffer.AsMemory(0, 2)).ConfigureAwait(false);
             var flags = BinaryPrimitives.ReadUInt16BigEndian(fourByteBuffer.AsSpan(0, 2));
             var isExtended = (flags & 0x4000) != 0;
 
@@ -94,14 +94,14 @@ internal class IndexReader(string path, IObjectResolver objectResolver, IFileSys
 
             if (version >= 3 && isExtended)
             {
-                read += await stream.ReadAsync(hash.AsMemory(0, 4));
+                read += await stream.ReadAsync(hash.AsMemory(0, 4)).ConfigureAwait(false);
             }
 
             var path = default(byte[]);
             if (version < 4)
             {
                 path = new byte[length];
-                read += await stream.ReadAsync(path.AsMemory(0, length));
+                read += await stream.ReadAsync(path.AsMemory(0, length)).ConfigureAwait(false);
             }
             else
             {

--- a/src/GitDotNet/Tools/GitPatchCreator.cs
+++ b/src/GitDotNet/Tools/GitPatchCreator.cs
@@ -31,13 +31,13 @@ public partial class GitPatchCreator(int unified = GitPatchCreator.DefaultUnifie
             NewLine = "\n"
         };
 
-        await GetHeaderAsync(writer, start, end);
+        await GetHeaderAsync(writer, start, end).ConfigureAwait(false);
         GetDiffStat(writer, changes);
 
         var indexLine = $"index {start?.Id.ToString()[..7] ?? "null"}..{end.Id.ToString()[..7]}";
         foreach (var change in changes)
         {
-            await CreatePatchAsync(writer, change, indexLine);
+            await CreatePatchAsync(writer, change, indexLine).ConfigureAwait(false);
         }
     }
 
@@ -46,12 +46,12 @@ public partial class GitPatchCreator(int unified = GitPatchCreator.DefaultUnifie
         var author = end.Author ?? throw new InvalidOperationException("Author is required.");
         if (start != null)
         {
-            await writer.WriteLineAsync($"From {start.Id} {author.Timestamp:ddd MMM dd HH:mm:ss yyyy}");
+            await writer.WriteLineAsync($"From {start.Id} {author.Timestamp:ddd MMM dd HH:mm:ss yyyy}").ConfigureAwait(false);
         }
-        await writer.WriteLineAsync($"From: {author.Name} <{author.Email}>");
-        await writer.WriteLineAsync($"Date: {author.Timestamp:ddd, dd MMM yyyy HH:mm:ss +0000}");
-        await writer.WriteLineAsync($"Subject: [PATCH] {end.Message}");
-        await writer.WriteLineAsync();
+        await writer.WriteLineAsync($"From: {author.Name} <{author.Email}>").ConfigureAwait(false);
+        await writer.WriteLineAsync($"Date: {author.Timestamp:ddd, dd MMM yyyy HH:mm:ss +0000}").ConfigureAwait(false);
+        await writer.WriteLineAsync($"Subject: [PATCH] {end.Message}").ConfigureAwait(false);
+        await writer.WriteLineAsync().ConfigureAwait(false);
     }
 
     internal static void GetDiffStat(StreamWriter writer, IList<Change> changes)
@@ -101,13 +101,13 @@ public partial class GitPatchCreator(int unified = GitPatchCreator.DefaultUnifie
 
     private async Task CreatePatchAsync(StreamWriter writer, Change change, string indexLine)
     {
-        await WritePathAsync(writer, "--- a/", change.OldPath);
-        await WritePathAsync(writer, "+++ b/", change.NewPath);
-        await writer.WriteLineAsync($"{indexLine} {change.New?.Mode ?? change.Old?.Mode}");
+        await WritePathAsync(writer, "--- a/", change.OldPath).ConfigureAwait(false);
+        await WritePathAsync(writer, "+++ b/", change.NewPath).ConfigureAwait(false);
+        await writer.WriteLineAsync($"{indexLine} {change.New?.Mode ?? change.Old?.Mode}").ConfigureAwait(false);
 
         // Hunks
-        var oldBlob = change.Old is not null ? await change.Old.GetEntryAsync<BlobEntry>() : null;
-        var newBlob = change.New is not null ? await change.New.GetEntryAsync<BlobEntry>() : null;
+        var oldBlob = change.Old is not null ? await change.Old.GetEntryAsync<BlobEntry>().ConfigureAwait(false) : null;
+        var newBlob = change.New is not null ? await change.New.GetEntryAsync<BlobEntry>().ConfigureAwait(false) : null;
         if ((oldBlob?.IsText ?? true) && (newBlob?.IsText ?? true))
         {
             var hunks = GetHunks(oldBlob?.OpenRead(), newBlob?.OpenRead());
@@ -118,7 +118,7 @@ public partial class GitPatchCreator(int unified = GitPatchCreator.DefaultUnifie
         }
         else
         {
-            await writer.WriteLineAsync("Binary files differ");
+            await writer.WriteLineAsync("Binary files differ").ConfigureAwait(false);
         }
     }
 
@@ -133,15 +133,15 @@ public partial class GitPatchCreator(int unified = GitPatchCreator.DefaultUnifie
 
     private static async Task WritePathAsync(StreamWriter writer, string prefix, GitPath? path)
     {
-        await writer.WriteAsync(prefix);
+        await writer.WriteAsync(prefix).ConfigureAwait(false);
         if (path is null)
         {
-            await writer.WriteLineAsync("dev/null");
+            await writer.WriteLineAsync("dev/null").ConfigureAwait(false);
         }
         else
         {
             path.AppendTo(writer);
-            await writer.WriteLineAsync();
+            await writer.WriteLineAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/GitDotNet/Tools/PooledMemoryStream.cs
+++ b/src/GitDotNet/Tools/PooledMemoryStream.cs
@@ -133,7 +133,7 @@ public class PooledMemoryStream(int initialCapacity = 4096) : Stream
         var remaining = count;
         while (remaining > 0)
         {
-            var read = await stream.ReadAsync(_buffer.AsMemory(_position, remaining));
+            var read = await stream.ReadAsync(_buffer.AsMemory(_position, remaining)).ConfigureAwait(false);
             if (read == 0) break;
             remaining -= read;
             _position += read;

--- a/src/GitDotNet/Tools/StreamExtensions.cs
+++ b/src/GitDotNet/Tools/StreamExtensions.cs
@@ -23,7 +23,7 @@ internal static class StreamExtensions
         var remaining = length;
         while (remaining > 0)
         {
-            var read = await stream.ReadAsync(result.AsMemory(position, (int)remaining));
+            var read = await stream.ReadAsync(result.AsMemory(position, (int)remaining)).ConfigureAwait(false);
             if (read == 0) break;
             remaining -= read;
             position += read;

--- a/src/GitDotNet/TransformationComposer.cs
+++ b/src/GitDotNet/TransformationComposer.cs
@@ -39,7 +39,7 @@ internal class TransformationComposer(string repositoryPath, FastInsertWriterFac
     {
         var updateBranch = options?.UpdateBranch ?? true;
         var importBranch = updateBranch ? CheckFullReferenceName(branch) : $"refs/gitdotnetfastimport/{Guid.NewGuid()}";
-        using var data = await WriteData(importBranch, commit);
+        using var data = await WriteData(importBranch, commit).ConfigureAwait(false);
         data.Seek(0, SeekOrigin.Begin);
         var markFile = GetMarkDownPath(repositoryPath, fileSystem);
         try
@@ -81,7 +81,7 @@ internal class TransformationComposer(string repositoryPath, FastInsertWriterFac
     {
         var result = new PooledMemoryStream();
         using var writer = FastInsertWriterFactory(result);
-        await writer.WriteHeaderAsync(branch, commit);
+        await writer.WriteHeaderAsync(branch, commit).ConfigureAwait(false);
         writer.WriteTransformations(this);
         return result;
     }

--- a/src/GitDotNet/Writers/FastInsertWriter.cs
+++ b/src/GitDotNet/Writers/FastInsertWriter.cs
@@ -79,13 +79,13 @@ internal sealed class FastInsertWriter : IDisposable
 
     public async Task WriteHeaderAsync(string branch, CommitEntry commit)
     {
-        await _writer.WriteLineAsync($"commit {branch}");
-        await _writer.WriteLineAsync($"mark :1");
-        if (commit.Author is not null) await WriteSignatureAsync("author", commit.Author);
-        if (commit.Committer is not null) await WriteSignatureAsync("committer", commit.Committer);
-        await _writer.WriteLineAsync($"data {Encoding.UTF8.GetByteCount(commit.Message)}");
-        await _writer.WriteLineAsync(commit.Message);
-        await WriteParentCommitsAsync(await commit.GetParentsAsync());
+        await _writer.WriteLineAsync($"commit {branch}").ConfigureAwait(false);
+        await _writer.WriteLineAsync($"mark :1").ConfigureAwait(false);
+        if (commit.Author is not null) await WriteSignatureAsync("author", commit.Author).ConfigureAwait(false);
+        if (commit.Committer is not null) await WriteSignatureAsync("committer", commit.Committer).ConfigureAwait(false);
+        await _writer.WriteLineAsync($"data {Encoding.UTF8.GetByteCount(commit.Message)}").ConfigureAwait(false);
+        await _writer.WriteLineAsync(commit.Message).ConfigureAwait(false);
+        await WriteParentCommitsAsync(await commit.GetParentsAsync().ConfigureAwait(false)).ConfigureAwait(false);
     }
 
     private async Task WriteSignatureAsync(string type, Signature signature) => await _writer.WriteLineAsync(
@@ -93,16 +93,16 @@ internal sealed class FastInsertWriter : IDisposable
         $"{signature.Name} " +
         $"<{signature.Email}> " +
         $"{signature.Timestamp.ToUnixTimeSeconds()} " +
-        $"{signature.Timestamp.Offset.Minutes:+0000;-0000}");
+        $"{signature.Timestamp.Offset.Minutes:+0000;-0000}").ConfigureAwait(false);
 
     private async Task WriteParentCommitsAsync(IList<CommitEntry> parents)
     {
         if (parents.Count >= 1)
         {
-            await _writer.WriteLineAsync($"from {parents[0].Id}");
+            await _writer.WriteLineAsync($"from {parents[0].Id}").ConfigureAwait(false);
             if (parents.Count >= 2)
             {
-                await _writer.WriteLineAsync($"merge {parents[1].Id}");
+                await _writer.WriteLineAsync($"merge {parents[1].Id}").ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
- **Fix performance regression by updating pack file list only when forced or when entry cannot be found**
- **Generalize usage of ConfigureAwait(false) to avoid deadlocks if calling service has synchronization context**
